### PR TITLE
[네비게이션 기능] 메인 , 게임 네비게이션 기능 추가

### DIFF
--- a/App.js
+++ b/App.js
@@ -3,8 +3,7 @@ import React from "react";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 
-import { GameLayout } from "./src/components";
-import { MainContainer } from "./src/features";
+import { MainContainer, Game1Container } from "./src/features";
 const Stack = createNativeStackNavigator();
 
 const App = () => {
@@ -18,8 +17,8 @@ const App = () => {
         />
 
         <Stack.Screen
-          name="GameLayout"
-          component={GameLayout}
+          name="Game1"
+          component={Game1Container}
           options={{ headerShown: false }}
         />
       </Stack.Navigator>

--- a/App.js
+++ b/App.js
@@ -1,9 +1,26 @@
 import React from "react";
 
+import { NavigationContainer } from "@react-navigation/native";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+
 import MainContainer from "./src/features/main";
+import Test from "./src/features/main/Test";
+
+const Stack = createNativeStackNavigator();
 
 const App = () => {
-  return <MainContainer />;
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="Main">
+        <Stack.Screen
+          name="Main"
+          component={MainContainer}
+          options={{ headerShown: false }}
+        />
+        <Stack.Screen name="Test" component={Test} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
 };
 
 export default App;

--- a/App.js
+++ b/App.js
@@ -3,9 +3,8 @@ import React from "react";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 
-import MainContainer from "./src/features/main";
-import Test from "./src/features/main/Test";
-
+import { GameLayout } from "./src/components";
+import { MainContainer } from "./src/features";
 const Stack = createNativeStackNavigator();
 
 const App = () => {
@@ -17,7 +16,12 @@ const App = () => {
           component={MainContainer}
           options={{ headerShown: false }}
         />
-        <Stack.Screen name="Test" component={Test} />
+
+        <Stack.Screen
+          name="GameLayout"
+          component={GameLayout}
+          options={{ headerShown: false }}
+        />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -355,6 +355,9 @@ PODS:
     - React-perflogger (= 0.68.1)
   - RNExitApp (1.1.0):
     - React
+  - RNScreens (3.13.1):
+    - React-Core
+    - React-RCTImage
   - RNVectorIcons (9.1.0):
     - React-Core
   - SocketRocket (0.6.0)
@@ -419,6 +422,7 @@ DEPENDENCIES:
   - React-runtimeexecutor (from `../node_modules/react-native/ReactCommon/runtimeexecutor`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - RNExitApp (from `../node_modules/react-native-exit-app`)
+  - RNScreens (from `../node_modules/react-native-screens`)
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
@@ -505,6 +509,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   RNExitApp:
     :path: "../node_modules/react-native-exit-app"
+  RNScreens:
+    :path: "../node_modules/react-native-screens"
   RNVectorIcons:
     :path: "../node_modules/react-native-vector-icons"
   Yoga:
@@ -556,6 +562,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 7285b499d0339104b2813a1f58ad1ada4adbd6c0
   ReactCommon: bf2888a826ceedf54b99ad1b6182d1bc4a8a3984
   RNExitApp: c4e052df2568b43bec8a37c7cd61194d4cfee2c3
+  RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   RNVectorIcons: 7923e585eaeb139b9f4531d25a125a1500162a0b
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: 17cd9a50243093b547c1e539c749928dd68152da

--- a/package.json
+++ b/package.json
@@ -10,10 +10,13 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@react-navigation/native": "^6.0.10",
+    "@react-navigation/native-stack": "^6.6.1",
     "react": "17.0.2",
     "react-native": "0.68.1",
     "react-native-exit-app": "^1.1.0",
     "react-native-safe-area-context": "^4.2.4",
+    "react-native-screens": "^3.13.1",
     "react-native-system-navigation-bar": "^1.0.4",
     "react-native-vector-icons": "^9.1.0"
   },

--- a/src/components/Buttons/SmallButton.js
+++ b/src/components/Buttons/SmallButton.js
@@ -27,7 +27,7 @@ const styles = StyleSheet.create({
   container: (bgColor) => {
     return {
       width: 80,
-      height: 35,
+      height: 40,
       backgroundColor: bgColor,
       borderRadius: 20,
       alignItems: "center",

--- a/src/components/Layouts/GameLayout.js
+++ b/src/components/Layouts/GameLayout.js
@@ -1,6 +1,7 @@
 import React from "react";
 
-import { View, StyleSheet, SafeAreaView } from "react-native";
+import { View, StyleSheet } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 import { GameHeader } from "../index";
 
@@ -12,7 +13,7 @@ import { GameHeader } from "../index";
 */
 const GameLayout = ({ children }) => {
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={styles.container} edges={["top"]}>
       <View style={styles.header}>
         <GameHeader onPressBack={() => console.log("go back to home!")} />
       </View>
@@ -24,13 +25,18 @@ const GameLayout = ({ children }) => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    backgroundColor: "#212529",
   },
   header: {
     height: "10%",
   },
   gameBoard: {
-    height: "90%",
-    backgroundColor: "lightblue",
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    width: "100%",
+    height: "100%",
+    backgroundColor: "#ffffff",
   },
 });
 

--- a/src/components/Timers/TextTimer.js
+++ b/src/components/Timers/TextTimer.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+
 import { View, Text, StyleSheet } from "react-native";
 
 const TextTimer = () => {

--- a/src/features/game1/container/Game1Container.js
+++ b/src/features/game1/container/Game1Container.js
@@ -1,0 +1,34 @@
+import React from "react";
+
+import { View, Text, StyleSheet } from "react-native";
+
+import { GameLayout } from "../../../components";
+
+const Game1Container = () => {
+  return (
+    <GameLayout>
+      <View style={styles.playArea}>
+        <Text>맵 영역</Text>
+      </View>
+
+      <View style={styles.recordArea}>
+        <Text>방향 기록 영역</Text>
+      </View>
+    </GameLayout>
+  );
+};
+
+const styles = StyleSheet.create({
+  playArea: {
+    width: "100%",
+    height: "80%",
+    backgroundColor: "#d8f5a2",
+  },
+  recordArea: {
+    width: "100%",
+    height: "20%",
+    backgroundColor: "#ffec99",
+  },
+});
+
+export default Game1Container;

--- a/src/features/game1/presenter/Game.js
+++ b/src/features/game1/presenter/Game.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Game = () => {
+  return <div />;
+};
+
+export default Game;

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -1,3 +1,4 @@
+import Game1Container from "./game1/container/Game1Container";
 import MainContainer from "./main";
 
-export { MainContainer };
+export { MainContainer, Game1Container };

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -1,0 +1,3 @@
+import MainContainer from "./main";
+
+export { MainContainer };

--- a/src/features/main/Test.js
+++ b/src/features/main/Test.js
@@ -1,9 +1,0 @@
-import React from "react";
-
-import { Text } from "react-native";
-
-const Test = () => {
-  return <Text>게임 화면 테스트 입니다.</Text>;
-};
-
-export default Test;

--- a/src/features/main/Test.js
+++ b/src/features/main/Test.js
@@ -1,0 +1,9 @@
+import React from "react";
+
+import { Text } from "react-native";
+
+const Test = () => {
+  return <Text>게임 화면 테스트 입니다.</Text>;
+};
+
+export default Test;

--- a/src/features/main/container/MainContainer.js
+++ b/src/features/main/container/MainContainer.js
@@ -5,7 +5,7 @@ import RNExitApp from "react-native-exit-app";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import SystemNavigationBar from "react-native-system-navigation-bar";
 
-import { DefaultButton, ContentModal } from "../../../components";
+import { DefaultButton, SmallButton, ContentModal } from "../../../components";
 import { game } from "../../../utils";
 import Main from "../presenter/Main";
 
@@ -42,7 +42,7 @@ const MainContainer = ({ navigation }) => {
   const handleStartGame = () => {
     setGameNumber(null);
     setDescriptionModalVisible(!descriptionModalVisible);
-    navigation.navigate("GameLayout");
+    navigation.navigate("Game1");
   };
 
   return (
@@ -75,10 +75,15 @@ const MainContainer = ({ navigation }) => {
           content={game.description[gameNumber]}
           isVisible={descriptionModalVisible}
         >
-          <DefaultButton
+          <SmallButton
             content="게임 시작"
             color="#69db7c"
             onPress={handleStartGame}
+          />
+          <SmallButton
+            content="닫기"
+            color="#e03131"
+            onPress={handleSelectGameNumberAndShowDescriptionModal()}
           />
         </ContentModal>
       )}

--- a/src/features/main/container/MainContainer.js
+++ b/src/features/main/container/MainContainer.js
@@ -42,7 +42,7 @@ const MainContainer = ({ navigation }) => {
   const handleStartGame = () => {
     setGameNumber(null);
     setDescriptionModalVisible(!descriptionModalVisible);
-    navigation.navigate("Test");
+    navigation.navigate("GameLayout");
   };
 
   return (

--- a/src/features/main/container/MainContainer.js
+++ b/src/features/main/container/MainContainer.js
@@ -6,10 +6,13 @@ import { SafeAreaProvider } from "react-native-safe-area-context";
 import SystemNavigationBar from "react-native-system-navigation-bar";
 
 import { DefaultButton, ContentModal } from "../../../components";
+import { game } from "../../../utils";
 import Main from "../presenter/Main";
 
-const MainContainer = () => {
-  const [modalVisible, setModalVisible] = useState(false);
+const MainContainer = ({ navigation }) => {
+  const [scoreModalVisible, setScoreModalVisible] = useState(false);
+  const [descriptionModalVisible, setDescriptionModalVisible] = useState(false);
+  const [gameNumber, setGameNumber] = useState(null);
 
   useEffect(() => {
     const hideSoftKey = async () => {
@@ -25,24 +28,57 @@ const MainContainer = () => {
     RNExitApp.exitApp();
   };
 
-  const handleShowModal = () => {
-    setModalVisible(!modalVisible);
+  const handleShowScoreModal = () => {
+    setScoreModalVisible(!scoreModalVisible);
+  };
+
+  const handleSelectGameNumberAndShowDescriptionModal = (n) => {
+    return () => {
+      setGameNumber(n);
+      setDescriptionModalVisible(!descriptionModalVisible);
+    };
+  };
+
+  const handleStartGame = () => {
+    setGameNumber(null);
+    setDescriptionModalVisible(!descriptionModalVisible);
+    navigation.navigate("Test");
   };
 
   return (
     <SafeAreaProvider>
-      <Main onExitApp={exitApp} handleShowModal={handleShowModal} />
+      <Main
+        onExitApp={exitApp}
+        handleShowScoreModal={handleShowScoreModal}
+        handleSelectGameNumberAndShowDescriptionModal={
+          handleSelectGameNumberAndShowDescriptionModal
+        }
+      />
 
-      {modalVisible && (
+      {scoreModalVisible && (
         <ContentModal
-          title="SCORE"
+          title="점수 현황"
           content="김춘식 : 100점"
-          isVisible={modalVisible}
+          isVisible={scoreModalVisible}
         >
           <DefaultButton
             content="닫기"
             color="#e03131"
-            onPress={handleShowModal}
+            onPress={handleShowScoreModal}
+          />
+        </ContentModal>
+      )}
+
+      {descriptionModalVisible && (
+        <ContentModal
+          title="게임 설명"
+          content={game.description[gameNumber]}
+          isVisible={descriptionModalVisible}
+        >
+          <DefaultButton
+            content="게임 시작"
+            color="#69db7c"
+            onPress={handleStartGame}
           />
         </ContentModal>
       )}
@@ -51,4 +87,3 @@ const MainContainer = () => {
 };
 
 export default MainContainer;
-// 게임선택 -> 설명 -> 게임이동

--- a/src/features/main/presenter/Main.js
+++ b/src/features/main/presenter/Main.js
@@ -6,7 +6,11 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { DefaultButton, SquareButton, Logo } from "../../../components";
 import { game } from "../../../utils";
 
-const Main = ({ onExitApp, handleShowModal }) => {
+const Main = ({
+  onExitApp,
+  handleShowScoreModal,
+  handleSelectGameNumberAndShowDescriptionModal,
+}) => {
   return (
     <SafeAreaView style={styles.container}>
       <StatusBar backgroundColor="#212529" barStyle="light-content" />
@@ -17,7 +21,12 @@ const Main = ({ onExitApp, handleShowModal }) => {
       <View style={styles.gameWrapper}>
         {game.names.map((v, i) => {
           return (
-            <SquareButton key={v} content={v} color={`${game.colors[i]}`} />
+            <SquareButton
+              key={v}
+              content={v}
+              color={game.colors[i]}
+              onPress={handleSelectGameNumberAndShowDescriptionModal(i)}
+            />
           );
         })}
       </View>
@@ -26,7 +35,7 @@ const Main = ({ onExitApp, handleShowModal }) => {
         <DefaultButton
           content="점수 보기"
           color="#69db7c"
-          onPress={handleShowModal}
+          onPress={handleShowScoreModal}
         />
       </View>
 

--- a/src/utils/property.js
+++ b/src/utils/property.js
@@ -1,8 +1,10 @@
 const gameNames = ["GAME 1", "GAME 2", "GAME 3"];
 const gameColors = ["#66d9e8", "#74c0fc", "#91a7ff"];
+const gameDescription = ["게임 설명 1111", "게임 설명 2222", "게임 설명 3333"];
 const game = {
   names: gameNames,
   colors: gameColors,
+  description: gameDescription,
 };
 
 export { game };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1236,6 +1236,47 @@
   resolved "https://registry.npmjs.org/@react-native/polyfills/-/polyfills-2.0.0.tgz"
   integrity sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==
 
+"@react-navigation/core@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-6.2.1.tgz#90459f9afd25b71a9471b0706ebea2cdd2534fc4"
+  integrity sha512-3mjS6ujwGnPA/BC11DN9c2c42gFld6B6dQBgDedxP2djceXESpY2kVTTwISDHuqFnF7WjvRjsrDu3cKBX+JosA==
+  dependencies:
+    "@react-navigation/routers" "^6.1.0"
+    escape-string-regexp "^4.0.0"
+    nanoid "^3.1.23"
+    query-string "^7.0.0"
+    react-is "^16.13.0"
+
+"@react-navigation/elements@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-1.3.3.tgz#9f56b650a9a1a8263a271628be7342c8121d1788"
+  integrity sha512-Lv2lR7si5gNME8dRsqz57d54m4FJtrwHRjNQLOyQO546ZxO+g864cSvoLC6hQedQU0+IJnPTsZiEI2hHqfpEpw==
+
+"@react-navigation/native-stack@^6.6.1":
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/@react-navigation/native-stack/-/native-stack-6.6.1.tgz#b0fc0dfc6fb21704062ec2820a53f982584feef2"
+  integrity sha512-JQfM3VWTH241ZQhp+UDJ6dZ/WiKJpGxNO4NFNW9AT+D1mxA3GFC3BBiGZfacPrtMOlLmn9FHf0Kh5rD9JYlvhg==
+  dependencies:
+    "@react-navigation/elements" "^1.3.3"
+    warn-once "^0.1.0"
+
+"@react-navigation/native@^6.0.10":
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-6.0.10.tgz#c58aa176eb0e63f3641c83a65c509faf253e4385"
+  integrity sha512-H6QhLeiieGxNcAJismIDXIPZgf1myr7Og8v116tezIGmincJTOcWavTd7lPHGnMMXaZg94LlVtbaBRIx9cexqw==
+  dependencies:
+    "@react-navigation/core" "^6.2.1"
+    escape-string-regexp "^4.0.0"
+    fast-deep-equal "^3.1.3"
+    nanoid "^3.1.23"
+
+"@react-navigation/routers@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-6.1.0.tgz#d5682be88f1eb7809527c48f9cd3dedf4f344e40"
+  integrity sha512-8xJL+djIzpFdRW/sGlKojQ06fWgFk1c5jER9501HYJ12LF5DIJFr/tqBI2TJ6bk+y+QFu0nbNyeRC80OjRlmkA==
+  dependencies:
+    nanoid "^3.1.23"
+
 "@sideway/address@^4.1.3":
   version "4.1.4"
   resolved "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz"
@@ -3033,6 +3074,11 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+filter-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
+  integrity sha1-mzERErxsYSehbgFsbF1/GeCAXFs=
 
 finalhandler@1.1.2:
   version "1.1.2"
@@ -4969,6 +5015,11 @@ ms@2.1.3, ms@^2.1.1:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+nanoid@^3.1.23:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
+  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz"
@@ -5545,6 +5596,16 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+query-string@^7.0.0:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.1.tgz#754620669db978625a90f635f12617c271a088e1"
+  integrity sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz"
@@ -5558,6 +5619,11 @@ react-devtools-core@^4.23.0:
     shell-quote "^1.6.1"
     ws "^7"
 
+react-freeze@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-freeze/-/react-freeze-1.0.0.tgz#b21c65fe1783743007c8c9a2952b1c8879a77354"
+  integrity sha512-yQaiOqDmoKqks56LN9MTgY06O0qQHgV4FUrikH357DydArSZHQhl0BJFqGKIZoTqi8JizF9Dxhuk1FIZD6qCaw==
+
 "react-is@^16.12.0 || ^17.0.0", react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz"
@@ -5568,7 +5634,7 @@ react-devtools-core@^4.23.0:
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.0.0.tgz"
   integrity sha512-yUcBYdBBbo3QiPsgYDcfQcIkGZHfxOaoE6HLSnr1sPzMhdyxusbfKOSUbSd/ocGi32dxcj366PsTj+5oggeKKw==
 
-react-is@^16.13.1:
+react-is@^16.13.0, react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -5597,6 +5663,14 @@ react-native-safe-area-context@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.2.4.tgz#4df42819759c4d3c74252c8678c2772cfa2271a6"
   integrity sha512-OOX+W2G4YYufvryonn6Kw6YnyT8ZThkxPHZBD04NLHaZmicUaaDVII/PZ3M5fD1o5N62+T+8K4bCS5Un2ggvkA==
+
+react-native-screens@^3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.13.1.tgz#b3b1c5788dca25a71668909f66d87fb35c5c5241"
+  integrity sha512-xcrnuUs0qUrGpc2gOTDY4VgHHADQwp80mwR1prU/Q0JqbZN5W3koLhuOsT6FkSRKjR5t40l+4LcjhHdpqRB2HA==
+  dependencies:
+    react-freeze "^1.0.0"
+    warn-once "^0.1.0"
 
 react-native-system-navigation-bar@^1.0.4:
   version "1.0.4"
@@ -6270,6 +6344,11 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz"
   integrity sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz"
@@ -6323,6 +6402,11 @@ stream-buffers@2.2.x:
   version "2.2.0"
   resolved "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz"
   integrity sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^4.0.1:
   version "4.0.2"
@@ -6840,6 +6924,11 @@ walker@^1.0.7, walker@~1.0.5:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
+
+warn-once@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/warn-once/-/warn-once-0.1.0.tgz#4f58d89b84f968d0389176aa99e0cf0f14ffd4c8"
+  integrity sha512-recZTSvuaH/On5ZU5ywq66y99lImWqzP93+AiUo9LUwG8gXHW+LJjhOd6REJHm7qb0niYqrEQJvbHSQfuJtTqA==
 
 wcwidth@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
카드에서 구현 혹은 해결하려는 내용

App.js
- 게임선택 -> 게임시작 -> 게임화면 네비게이션

package.json
-"@react-navigation/native": "^6.0.10"
-"@react-navigation/native-stack": "^6.6.1"
-"react-native-screens": "^3.13.1"

설치 / 실행
( yarn install -> cd ios -> pod install -> cd - -> yarn ios -> yarn android )

property.js
추후 gameNames, gameColors, gameDescription 확정시 변경 필요
gameNames : Main UI 에서 각 게임 선택 버튼의 텍스트
gameColors: Main UI 에서 각 게임 선택 버튼의 색상
gameDescription: Main UI 에거 각 게임 선택 시 Modal 에서 설명 content 부분 (이미지로 변경시 path를 문자열로 넣어두면 좋을것 같습니다.)

현재 게임선택 -> 게임시작 누르면 민지님이 작업한 GameLayout으로 넘어가도록 했습니다.
뒤로가기 기능이 없어 Metro에서 R 누르시면 메인화면으로 초기화 됩니다.
